### PR TITLE
Remove unneded installs

### DIFF
--- a/ink.scribl.Scribl.json
+++ b/ink.scribl.Scribl.json
@@ -31,11 +31,8 @@
             "cargo --offline fetch --manifest-path Cargo.toml --verbose",
             "cargo --offline build --release --verbose",
             "install -D target/release/scribl /app/bin/scribl",
-            "install -D metadata/ink.scribl.Scribl.appdata.xml /app/share/metainfo/ink.scribl.Scribl.appdata.xml",
+            "install -D metadata/ink.scribl.Scribl.appdata.xml /app/share/metainfo/ink.scribl.Scribl.metainfo.xml",
             "install -D metadata/ink.scribl.Scribl.svg /app/share/icons/hicolor/scalable/apps/ink.scribl.Scribl.svg",
-            "install -D metadata/ink.scribl.Scribl.128x128.png /app/share/icons/hicolor/128x128/apps/ink.scribl.Scribl.png",
-            "install -D metadata/ink.scribl.Scribl.128x128.png /app/share/app-info/icons/flatpak/128x128/ink.scribl.Scribl.png",
-            "install -D metadata/ink.scribl.Scribl.256x256.png /app/share/icons/hicolor/256x256/apps/ink.scribl.Scribl.png",
             "install -D metadata/ink.scribl.Scribl.desktop /app/share/applicatons/ink.scribl.Scribl.desktop"
         ]
     }]


### PR DESCRIPTION
As you're already installing the scalable version of the icon, the other variants are not required. The extension of the metainfo file should be .metainfo if you install it under /metainfo (which is the correct & new path).